### PR TITLE
Fix minification issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ class Radio extends Component {
     var targetIndex = selectedIndex !== -1? selectedIndex : this.props.defaultSelect;
 
     var children = React.Children.map(this.props.children, (child, index) => {
-      if (child.type.name == 'Option') {
+      if (child.type === Option) {
         return React.cloneElement(child, {
           onPress: () => this._onSelect(index),
           isSelected: index == targetIndex

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-radio-button-classic",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Bring Classic Radio to React-Native",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This replaces `type.name` comparison by comparing the type constructor function directory against `Option`. This ensures code path still works after minification.
