### PR TITLE
Upgrading to use React API directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ project.xcworkspace
 #
 node_modules/
 npm-debug.log
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,14 @@
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 
 var {
   Dimensions,
   StyleSheet,
-  Component,
   View,
   TouchableWithoutFeedback
-} = React;
+} = ReactNative;
+
+var {Component} = React;
 
 var window = Dimensions.get('window');
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "url": "git@github.com:pressly/react-native-radio-button-classic.git"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": "*",
+    "react": "*"
   },
   "keywords": [
     "react-component",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-radio-button-classic",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Bring Classic Radio to React-Native",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
According to [v0.25.1](https://github.com/facebook/react-native/releases/tag/v0.25.1) release notes, `Requiring React API from react-native is now deprecated`. So I changed the package to use React API via `react` instead of using it via `react-native`.
