### PR TITLE
Code upgrade for react native version > 0.25.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
-var React = require('react-native');
+var ReactNative = require('react-native');
+var React = require('react');
 
+var React, { Component } = React;
 var {
   Dimensions,
   StyleSheet,
-  Component,
   View,
   TouchableWithoutFeedback
-} = React;
+} = ReactNative;
 
 var window = Dimensions.get('window');
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "url": "git@github.com:pressly/react-native-radio-button-classic.git"
   },
   "peerDependencies": {
-    "react-native": "*"
+    "react-native": "*",
+    "react": "*"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
Hi, 
I was using your react-native-radio-button-classic component in React Native 0.34 version and get this error: 

![screenshot from 2016-10-09 02-57-19](https://cloud.githubusercontent.com/assets/11479975/19216832/3173d6a6-8dcc-11e6-8829-dc63d6a603c8.png)

This error will occur if you're using React Native version higher than 0.25.1 so I decided to upgrade your code.
